### PR TITLE
Redefine User model: Settings already unmarshalled map[string]any

### DIFF
--- a/core/domain/user.go
+++ b/core/domain/user.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -12,7 +11,7 @@ import (
 type User struct {
 	ID       uuid.UUID
 	Name     string
-	Settings []byte
+	Settings map[string]any // Make sure, that the JSONB submitted to the database is actually a map (not an array)
 	LastSeen *time.Time
 }
 
@@ -45,9 +44,7 @@ func (u User) String() string {
 	}
 
 	if u.Settings != nil {
-		var settings map[string]any
-		_ = json.Unmarshal(u.Settings, &settings)
-		result += fmt.Sprintf(", settings %v", settings)
+		result += fmt.Sprintf(", settings %v", u.Settings)
 	}
 
 	return result


### PR DESCRIPTION
This bids for data validation when Settings are inserted into the database.  These cannot be just any JSON, particularly an array, but only a `map[string]any`-comliant objects.

With PostgreSQL (as of 16.1) JSON schema validation is not natively supported.  There are plugins for that ([1], [2]), but I am not inclined towards using them - makes setup slightly more complex.  Instead let's make sure that only JSON objects are allowed to be stored as `User.Settings` in Go functions which will insert/update these records.

[1] https://github.com/gavinwahl/postgres-json-schema
[2] https://github.com/supabase/pg_jsonschema